### PR TITLE
Add PostgreSQL 15/PostGIS 3.3/3.4

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -8,13 +8,8 @@ cd "${SCRIPT_DIR}"
 
 # Key is the PostgreSQL version and values are the PostGIS versions images are available for that PostgreSQL version.
 declare -A IMAGE_VERSIONS=(
-  [14]="3.2 3.1"
-  [13]="3.2 3.1 3.0"
-  [12]="3.2 3.1 3.0 2.5"
-  [11]="3.1 3.0 2.5"
-  [10]="3.1 3.0 2.5"
-  [9.6]="3.1 3.0 2.5"
-  [9.5]="3.0 2.5"
+  [15]="3.4 3.3"
+  [14]="3.4 3.3"
 )
 
 # Read in current version of the script


### PR DESCRIPTION
Maybe we should stop implementing legacy versions.
For now we will support PostgreSQL 14/15 and PostGIS 3.3/3.4.