### PR TITLE
Updated gem versions

### DIFF
--- a/docker/Dockerfile.template
+++ b/docker/Dockerfile.template
@@ -15,8 +15,8 @@ RUN apk update && apk upgrade \
     && echo 'gem: --no-document' > /etc/gemrc \
     \
     # install needed (ruby)gems
-    && gem install net-ssh -v 4.2.0 \
-    && gem install net-sftp -v 2.1.2 \
+    && gem install net-ssh -v 7.2.0 \
+    && gem install net-sftp -v 4.0.0 \
     && gem install clbustos-rtf \
     && ruby --version \
     && gem list \


### PR DESCRIPTION
I've been using 6.1.0 for net-ssh locally for years already, and that seems to work OK. Local testing seems to indicate these versions (which are the latest of these gems) work as well. Then again, I work on Windows, and just installed the gems on an existing installation while removing the old version. Fresh install on linux might behave differently, but one way to find out.