### PR TITLE
Set SFTP encryption to use

### DIFF
--- a/bin/SFTPUploader.rb
+++ b/bin/SFTPUploader.rb
@@ -27,7 +27,7 @@ class SFTPUploader
   def connect(host, port, username, password, remote_path)
     @logger.log "SFTP connect: #{host}:#{port}, username: #{username}, remote folder: #{remote_path}"
     begin
-      @sftp = Net::SFTP.start(host, username, { :port => port, :password => password, :compression => false })
+      @sftp = Net::SFTP.start(host, username, { :port => port, :password => password, :compression => false, :encryption => '3des-cbc' })
     rescue Net::SSH::Exception => e
       if e.message.include?('Creation of file mapping failed with error: 998') then
         raise e, "#{e} -- Possible fix: Try closing Pageant.exe", e.backtrace


### PR DESCRIPTION
This is actually a workaround.
We used to use an old net-ssh/net-sftp combination to get it to work,
 but with the new PostgreSQL/PostGIS container this won't work anymore
  as it uses OpenSSL 3 and these older libraries do not support it.
After some debugging a colleague found out it the issue gets triggered
  after a key renegotiation is done on the SSH level.
We can tweak this a bit here and there but also changing the encryption
  seems to have the desired effect as well, because of reasons.
For now this should suffice as a quick fix, but we should either fix it on
 a server level or get rid of SFTP entirely.

 PS: Hoping we'll move to HTTPS instead actually. :)