### PR TITLE
AER-138 HTTPS download support and .gz file support

### DIFF
--- a/bin/HTTPSUploader.rb
+++ b/bin/HTTPSUploader.rb
@@ -1,0 +1,111 @@
+require 'net/http'
+require 'openssl'
+require 'uri'
+require 'time'
+
+##
+# Utility class for several HTTPS actions. Similar to FTPUploader and SFTPUploader so easily interchangeable.
+#
+class HTTPSUploader
+
+  def initialize(logger)
+    @logger = logger
+    @base_url = nil
+    @currdir = ''
+  end
+
+  def connect(base_url, username, password)
+    @logger.log "HTTPS connect: #{base_url}, username: #{username}"
+    @base_url = base_url
+    @username = username
+    @password = password
+  end
+
+  def upload_file(filename)
+    raise "Upload file not supported with HTTPS version"
+  end
+  def upload_binary_file(filename); upload_file(filename); end
+  def upload_text_file(filename); upload_file(filename); end
+
+  def download_file(filename, download_to_path)
+    @logger.log "HTTPS download: #{filename}"
+    
+    uri = URI(@base_url + filename)
+
+    Net::HTTP.start(uri.host, uri.port, :use_ssl => true) do |http|
+      req = Net::HTTP::Get.new(uri.request_uri)
+      set_auth(req)
+      resp = http.request(req)
+      open(download_to_path, "wb") do |file|
+          file.write(resp.body)
+      end
+    end
+  end
+  def download_binary_file(filename, download_to_path); download_file(filename, download_to_path); end
+  def download_text_file(filename, download_to_path); download_file(filename, download_to_path); end
+
+  def disconnect
+    @logger.log "HTTPS disconnect"
+  end
+
+  def getdir
+    return @currdir
+  end
+
+  def chdir(remote_path)
+    @currdir = remote_path.fix_pathname
+  end
+
+  def mkpath(remote_path)
+    raise "Creating remote path not supported with HTTPS version"
+  end
+
+  def dir_exists?(remote_path)
+    # No way to check this (afaik), but probably not needed as it's only needed in upload.
+  end
+
+  def file_exists?(remote_file)
+    uri = URI(@base_url + @currdir + remote_file)
+    Net::HTTP.start(uri.host, uri.port, :use_ssl => true) do |http|
+      req = Net::HTTP::Head.new(uri.request_uri)
+      set_auth(req)
+      resp = http.request(req)
+      status_code = resp.code.to_i
+      @logger.error "Unexpected http status code: #{status_code}" unless status_code == 200 || status_code == 404
+      return status_code == 200
+    end
+  end
+
+  def file_size(remote_file)
+    uri = URI(@base_url + @currdir + remote_file)
+    Net::HTTP.start(uri.host, uri.port, :use_ssl => true) do |http|
+      req = Net::HTTP::Head.new(uri.request_uri)
+      set_auth(req)
+      resp = http.request(req)
+      return resp.content_length
+    end
+  end
+
+  def file_mtime(remote_file)
+    uri = URI(@base_url + @currdir + remote_file)
+    Net::HTTP.start(uri.host, uri.port, :use_ssl => true) do |http|
+      req = Net::HTTP::Head.new(uri.request_uri)
+      set_auth(req)
+      resp = http.request(req)
+      return Time.parse(resp.get_fields('last-modified')[0])
+    end
+  end
+
+  def get_filenames(remote_path, pattern = '*')
+    files = []
+		# Unsure if this possible and/or required.
+    return files
+  end
+
+  private
+
+  def set_auth(req)
+    req.basic_auth @username, @password unless $https_data_username.nil? || $https_data_password.nil?
+  end
+
+end

--- a/bin/Settings.rb
+++ b/bin/Settings.rb
@@ -63,7 +63,11 @@ else
 end
 #$svn_root_url = 'https://repository...' # Override in ..\AppSettings.rb
 
-# SFTP for syncing data files
+# HTTPS for syncing data files
+$https_data_path = 'https://a.b.c/xyz' # Override in ..\AppSettings.rb
+$https_data_username = 'REDACTED' # Override in ..\UserSettings.rb
+$https_data_password = 'REDACTED' # Override in ..\UserSettings.rb
+# or SFTP
 $sftp_data_path = 'sftp://a.b.c/xyz' # Override in ..\AppSettings.rb
 $sftp_data_readonly_username = 'REDACTED' # Override in ..\UserSettings.rb
 $sftp_data_readonly_password = 'REDACTED' # Override in ..\UserSettings.rb

--- a/bin/SyncDBData.rb
+++ b/bin/SyncDBData.rb
@@ -367,7 +367,7 @@ end
 
 def sync_gzipped(datasource, copy_from)
   gzip_copy_from = "#{copy_from}.gz"
-	print "  #{gzip_copy_from} ... "
+  print "  #{gzip_copy_from} ... "
   
   copy_to = datasource.gsub('{data_folder}', $target_path)
   make_file_dir(copy_to, $tgt_fs)

--- a/bin/SyncDBData.rb
+++ b/bin/SyncDBData.rb
@@ -79,13 +79,13 @@ $from_https = $https_data_path.fix_pathname + $dbdata_dir.fix_pathname unless $h
 
 # ---------
 
-$source = nil
-$target = nil
 $source_path = nil
 $target_path = nil
 $src_fs = nil
 $tgt_fs = nil
 $continue = false
+$source_overwritten = false
+$target_overwritten = false
 
 # ---------
 
@@ -105,32 +105,39 @@ def parse_commandline
     case option.downcase
       when '--path'; $product_data_path = File.expand_path(argument.to_s).fix_pathname
       when '--from-ftp'
-        raise 'Can only have one source' unless $source.nil?
+        raise 'Can only have one source' if $source_overwritten
         $source = :ftp
+        $source_overwritten = true
         $from_ftp = argument.to_s.fix_pathname unless argument.to_s.strip.empty?
       when '--from-sftp'
-        raise 'Can only have one source' unless $source.nil?
+        raise 'Can only have one source' if $source_overwritten
         $source = :sftp
+        $source_overwritten = true
         $from_sftp = argument.to_s.fix_pathname unless argument.to_s.strip.empty?
       when '--from-https'
-        raise 'Can only have one source' unless $source.nil?
+        raise 'Can only have one source' if $source_overwritten
         $source = :https
+        $source_overwritten = true
         $from_https = argument.to_s.fix_pathname unless argument.to_s.strip.empty?
       when '--from-local'
-        raise 'Can only have one source' unless $source.nil?
+        raise 'Can only have one source' if $source_overwritten
         $source = :local
+        $source_overwritten = true
         $from_local = File.expand_path(argument.to_s).fix_pathname unless argument.to_s.strip.empty?
       when '--to-ftp'
-        raise 'Can only have one target' unless $target.nil?
+        raise 'Can only have one target' if $target_overwritten
         $target = :ftp
+        $target_overwritten = true
         $to_ftp = argument.to_s.fix_pathname unless argument.to_s.strip.empty?
       when '--to-sftp'
-        raise 'Can only have one target' unless $target.nil?
+        raise 'Can only have one target' if $target_overwritten
         $target = :sftp
+        $target_overwritten = true
         $to_sftp = argument.to_s.fix_pathname unless argument.to_s.strip.empty?
       when '--to-local'
-        raise 'Can only have one target' unless $target.nil?
+        raise 'Can only have one target' if $target_overwritten
         $target = :local
+        $target_overwritten = true
         $to_local = File.expand_path(argument.to_s).fix_pathname unless argument.to_s.strip.empty?
       when '--continue'
         $continue = true

--- a/bin/SyncDBData.rb
+++ b/bin/SyncDBData.rb
@@ -403,10 +403,10 @@ def sync
       max_attempts = 5
       begin
         counter += 1
-        if file_exists(copy_from, $src_fs) then
-          sync_normal(datasource, copy_from)
-        elsif file_exists("#{copy_from}.gz", $src_fs) then
+        if file_exists("#{copy_from}.gz", $src_fs) then
           sync_gzipped(datasource, copy_from)
+        elsif file_exists(copy_from, $src_fs) then
+          sync_normal(datasource, copy_from)
         else
           if $continue then
             $logger.writeln "File not found: #{copy_from}" unless is_infofile

--- a/bin/SyncDBData.rb
+++ b/bin/SyncDBData.rb
@@ -144,7 +144,7 @@ def parse_commandline
   elsif $source == :sftp then
     $logger.writeln "Syncing from SFTP (#{$from_sftp})"
   elsif $source == :https then
-    $logger.writeln "Syncing from SFTP (#{$from_https})"
+    $logger.writeln "Syncing from HTTPS (#{$from_https})"
   elsif $source == :local then
     $logger.writeln "Syncing from local (#{$from_local})"
   end


### PR DESCRIPTION
Similar to the existing sftp and ftp downloaders.

Tested with a nexus installation that uses authentication and on Windows, that worked OK. In theory it should also support unauthenticated locations. username/password for https are optional, if not present it won't try to add them as basic authentication.

GZipped files support is now also supported. This should also work with the (S)FTP approach, though did not test this.

In a follow-up PR I want to remove the upload-functionality, renaming some existing classes in the process.