### PR TITLE
Efficient way of downloading big files

### DIFF
--- a/bin/HTTPSDownloader.rb
+++ b/bin/HTTPSDownloader.rb
@@ -29,9 +29,12 @@ class HTTPSDownloader
     Net::HTTP.start(uri.host, uri.port, :use_ssl => true) do |http|
       req = Net::HTTP::Get.new(uri.request_uri)
       set_auth(req)
-      resp = http.request(req)
-      open(download_to_path, "wb") do |file|
-          file.write(resp.body)
+      http.request(req) do |resp|
+        open(download_to_path, "wb") do |file|
+          resp.read_body do |body|
+            file.write(body)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
As it was, the body was retrieved in one go and kept in memory until it was written to disk, and that caused some issues on windows machines. This read_body approach writes chunks directly to the file, which fixes the issue (for me locally at least) and should be more efficient overall.