### PR TITLE
Fix some issues with prefixes

### DIFF
--- a/bin/DataSourceCollector.rb
+++ b/bin/DataSourceCollector.rb
@@ -83,7 +83,7 @@ class DataSourceCollector
         in_comment = false
       end
 
-      if !in_comment && line =~ /system\.load_table\s*\(\s*\'(.*)\'.*,\s*\'(\{data\_folder\}.+\.txt)\'/i then
+      if !in_comment && line =~ /#{$db_essentials_function_prefix}load_table\s*\(\s*\'(.*)\'.*,\s*\'(\{data\_folder\}.+\.txt)\'/i then
         table = $1
         datasource = $2
         datasource.gsub!('{data_folder}', data_folder) unless data_folder.nil?

--- a/bin/ScriptCommands.rb
+++ b/bin/ScriptCommands.rb
@@ -366,9 +366,9 @@ class ScriptCommands
     $logger.writeln_with_timing("Validating database contents...") {
       PostgresTools.execute_sql_command("\\set VERBOSITY terse \n SELECT #{$db_essentials_function_prefix}validate_all()");
       if params.include?(:abort_on_errors) then
-        rs = PostgresTools.fetch_sql_command("SELECT number_of_tests FROM system.last_validation_run_view WHERE result = 'error'");
+        rs = PostgresTools.fetch_sql_command("SELECT number_of_tests FROM #{$db_essentials_function_prefix}last_validation_run_view WHERE result = 'error'");
         num_errors = rs[0]['number_of_tests'].to_i
-        $logger.error "Validation yielded #{num_errors} error(s), please consult the logs and system.last_validation_logs_view" if num_errors > 0
+        $logger.error "Validation yielded #{num_errors} error(s), please consult the logs and #{$db_essentials_function_prefix}last_validation_logs_view" if num_errors > 0
       end
     }
   end

--- a/bin/Settings.rb
+++ b/bin/Settings.rb
@@ -41,7 +41,7 @@ $dbdata_dir = 'db-data/'
 $org_dir = 'org/'
 
 $db_essentials_function_prefix = 'system.'
-$db_unittest_prefix = 'system.unittest_'
+$db_unittest_prefix = 'unittest_'
 
 # VCS
 $vcs = nil  # :git or :svn

--- a/bin/Settings.rb
+++ b/bin/Settings.rb
@@ -36,8 +36,8 @@ $database_collation = '' # Can override in ..\AppSettings.rb in case you need to
 
 $on_build_server = false
 
-# Datasource files .. relative paths on the FTP
-$dbdata_dir = 'db-data/'
+# Datasource files .. common relative paths compared to base paths like https_data_path
+$dbdata_dir = 'dbdata/'
 $org_dir = 'org/'
 
 $db_essentials_function_prefix = 'system.'

--- a/bin/Settings.rb
+++ b/bin/Settings.rb
@@ -34,8 +34,6 @@ $database_collation = '' # Can override in ..\AppSettings.rb in case you need to
 
 #$database_name_prefix = '...' # Override in ..\AppSettings.rb
 
-$on_build_server = false
-
 # Datasource files .. common relative paths compared to base paths like https_data_path
 $dbdata_dir = 'dbdata/'
 $org_dir = 'org/'


### PR DESCRIPTION
The `db_essentials_function_prefix` variable wasn't used everywhere yet, so if you'd try to have another schema it wouldn't work for all functionality.

Also changed the default for `db_unittest_prefix` to something that works (if you use a schema in that variable, no test will be found).