### PR TITLE
Fix store_table search_path string_to_array delimiter

### DIFF
--- a/common/src/main/sql/database-build/essentials/load-store-data.sql
+++ b/common/src/main/sql/database-build/essentials/load-store-data.sql
@@ -136,7 +136,7 @@ BEGIN
 			FROM
 				(SELECT column_name
 					FROM information_schema.columns
-					WHERE (CASE WHEN table_schema = ANY (string_to_array(current_setting('search_path'), ',')) 
+					WHERE (CASE WHEN table_schema = ANY (string_to_array(current_setting('search_path'), ', ')) 
 						THEN table_name 
 						ELSE table_schema || '.' || table_name END)::text = tablename::text
 					ORDER BY ordinal_position


### PR DESCRIPTION
The returned `current_setting('search_path')` value always contains a space after each comma, which was causing spaces before each value (except the first) when parsed.