### PR TITLE
Adjust httpsdownloader to avoid double slashes in URI

### DIFF
--- a/bin/HTTPSDownloader.rb
+++ b/bin/HTTPSDownloader.rb
@@ -24,7 +24,7 @@ class HTTPSDownloader
   def download_file(filename, download_to_path)
     @logger.log "HTTPS download: #{filename}"
     
-    uri = URI(@base_url + filename)
+    uri = URI(@base_url + filename.delete_prefix('/'))
 
     Net::HTTP.start(uri.host, uri.port, :use_ssl => true) do |http|
       req = Net::HTTP::Get.new(uri.request_uri)
@@ -50,7 +50,7 @@ class HTTPSDownloader
   end
 
   def chdir(remote_path)
-    @currdir = remote_path.fix_pathname
+    @currdir = remote_path.fix_pathname.delete_prefix('/')
   end
 
   def file_exists?(remote_file)


### PR DESCRIPTION
New nexus version has an issue with double slashes followed by a relative path `base/something//../whatever` gets resolved to `base/something/whatever` instead of `base/whatever'. As we were relying on this last bit, now adjusted the https download script to avoid that double slash in the constructed URIs.